### PR TITLE
Support ignoring pre-releases

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -52,8 +52,9 @@ interface CustomPolicy extends Policy {
 }
 
 interface PolicyConfiguration {
-  primary?: PrimaryPolicy
-  custom?: CustomPolicy[]
+  primary?: PrimaryPolicy;
+  custom?: CustomPolicy[];
+  ignorePrereleases?: boolean;
 }
 ```
 
@@ -69,6 +70,10 @@ We should evaluate the config file up front and throw if there are conflicts. We
 This configuration is designed to be used when rolling out a support policy. If you were to simply turn on a support policy, for example on `July 1st 2021`, and package `foo` had released version `2.0.0` on `August 1st 2020`, than consumers of `foo` still on `foo@1.x` would only have 1 quarter to upgrade `foo` from `1.x` to `2.x`. In this scenario, you would want to set `effectiveReleaseDate` to `7/1/2021`, which will cause the support policy tool to act as if all dependency versions were released on that that date, meaning that consumers would not need to upgrade to `2.x` until `10/1/2022`, giving them 4 full quarters to upgrade to a major version, which is the intent of the policy.
 
 The `effectiveReleaseDate` in a custom policy takes precedence over the primary `effectiveReleaseDate`, for the packages specified in the given custom policy. This allows a policy owner to "un-ignore" a package without suddenly requiring everyone to upgrade immediately who isn't on the latest version of the ignored package.
+
+### `ignorePrereleases`
+
+By default, the latest `major`/`minor`/`patch` version is tagged in the public npm repository as the latest version, ignoring any prereleases. However, proprietary, private package repositories sometimes will consider the highest version to be the latest, including prereleases, like beta versions. `ignorePrereleases` lets you always ignore `prerelease`, `prepatch`, and `preminor` versions, regardless of the repository `latest` tag. By ignore, we mean, the support policy will never ask you to upgrade to a `prerelease`, `prepatch`, or `preminor` version.
 
 ## Examples
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -28,6 +28,7 @@ async function main(cli, { policyDetails, setupProjectFn }) {
       let configuredPolicies = JSON.parse(configFile);
 
       require('./validate-config')(configuredPolicies);
+      policies.ignorePrereleases = configuredPolicies.ignorePrereleases;
       if (configuredPolicies.primary) {
         policies.primary = configuredPolicies.primary;
         if (configuredPolicies.primary.ignoredDependencies) {

--- a/lib/config-schema.json
+++ b/lib/config-schema.json
@@ -27,6 +27,9 @@
         },
         "effectiveReleaseDate": { "type": "string" }
       }
-    }}
+    }},
+    "ignorePrereleases": {
+      "type": "boolean"
+    }
   }
 }

--- a/lib/project/index.js
+++ b/lib/project/index.js
@@ -91,10 +91,14 @@ module.exports = async function isInSupportWindow(
             result = supported(
               info,
               `${name}@${resolvedVersion}`,
-              supportedRanges(info.time[getLatest(info)], upgradeBudget),
+              supportedRanges(
+                info.time[getLatest(info, policies.ignorePrereleases)],
+                upgradeBudget,
+              ),
               today,
               effectiveReleaseDate,
               upgradeBudget,
+              policies.ignorePrereleases,
             );
             if (isSemVerSupported && !result.isSupported) {
               isSemVerSupported = false;
@@ -107,7 +111,7 @@ module.exports = async function isInSupportWindow(
             ...result,
             name,
             resolvedVersion,
-            latestVersion: getLatest(info),
+            latestVersion: getLatest(info, policies.ignorePrereleases),
           });
           progressLogger.updateSpinner(
             name,

--- a/lib/time/index.js
+++ b/lib/time/index.js
@@ -74,6 +74,9 @@ function deprecationDates(_release, upgradeBudget = DEFAULT_PRIMARY_POLICY.upgra
     major,
     minor,
     patch,
+    prerelease: major,
+    preminor: minor,
+    prepatch: patch,
   };
 }
 
@@ -103,11 +106,19 @@ function findNextVersionReleaseDate(_version, info, type) {
 }
 
 module.exports.supported = supported;
-function supported(info, packageName, policies, _today, effectiveReleaseDate, upgradeBudget) {
+function supported(
+  info,
+  packageName,
+  policies,
+  _today,
+  effectiveReleaseDate,
+  upgradeBudget,
+  ignorePrereleases,
+) {
   const { version } = parsePackageName(packageName);
 
   // TODO: if there is not latest, then return unsupported with caused relate to the lack of it being published: "pre-release"
-  const latestVersion = semver.parse(getLatest(info));
+  const latestVersion = semver.parse(getLatest(info, ignorePrereleases));
 
   const semverCoerce = semver.coerce(version);
   const parsed = semver.parse(semverCoerce);

--- a/lib/util.js
+++ b/lib/util.js
@@ -42,12 +42,25 @@ function dateDiff(a, b) {
 }
 
 /**
- *
+ * Return the latest version string, ignoring pre-releases.
  * @param {InfoObject} info information about package received from the npm registry
+ * @param {Boolean} ignorePrereleases if true, ignore prepatch, preminor, and prereleases
  */
 module.exports.getLatest = getLatest;
-function getLatest(info) {
-  return info['dist-tags'].latest;
+function getLatest(info, ignorePrereleases) {
+  const taggedLatest = info['dist-tags'].latest;
+  if (!ignorePrereleases || semver.parse(taggedLatest).prerelease.length === 0) {
+    return taggedLatest;
+  } else {
+    return Object.keys(info.versions)
+      .filter(version => {
+        return semver.parse(version).prerelease.length === 0;
+      })
+      .sort((a, b) => {
+        return semver.compare(a, b);
+      })
+      .pop();
+  }
 }
 
 /**

--- a/tests/time-based-test.js
+++ b/tests/time-based-test.js
@@ -57,6 +57,33 @@ describe('time based policy: 1 year for major, 6 months for minor, 3 months of p
     ).to.eql({ isSupported: true });
   });
 
+  it('ignores pre-releases when configured', function () {
+    expect(
+      supported(
+        {
+          version: '1.0.0',
+          time: {
+            '1.0.0': 'never',
+          },
+          'dist-tags': {
+            latest: '2.0.0-beta.16',
+          },
+          versions: {
+            '2.0.0-beta.16': {},
+            '1.0.0': {},
+            '0.5.0': {},
+          },
+        },
+        'example@1.0.0',
+        [],
+        null,
+        null,
+        null,
+        true,
+      ),
+    ).to.eql({ isSupported: true });
+  });
+
   it('returns true, when no policies are provide but versions have been published', function () {
     expect(
       supported(


### PR DESCRIPTION
For working with private/proprietary npm repos, we need to be able to configure ignoring prereleases. Ideally, proprietary repos should support managing the latest tag, but unfortunately that is not the case. This is only needed for (and we only intend for this flag to be turned on for) folks working on a private npm repo.

Without this change, some proprietary npm repo products will expect consumers to upgrade to a beta/alpha version, which we do not want normally.

https://github.com/stefanpenner/supported/issues/34