### PR TITLE
Change public API to accept configuration file

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -10,7 +10,6 @@ const { displayResults } = require('../lib/output/cli-output');
 const { processPolicies } = require('../lib/project/multiple-projects');
 const { DEFAULT_SUPPORT_MESSAGE } = require('./output/messages');
 const { generateCsv } = require('../lib/output/csv-output');
-const { getPolicyRules } = require('./policy-rules');
 
 async function main(cli, { policyDetails, setupProjectFn }) {
   const projectPaths = handleInput(cli.input, process.cwd());
@@ -20,25 +19,15 @@ async function main(cli, { policyDetails, setupProjectFn }) {
   } else {
     const currentDate = processDate(cli.flags.currentDate) || undefined;
 
-    let config = null;
-    if (cli.flags.configFile) {
-      let configFile = fs.readFileSync(cli.flags.configFile, 'utf-8');
-      config = JSON.parse(configFile);
-    }
-
-    const policyRules = getPolicyRules(config);
+    const config = cli.flags.configFile
+      ? JSON.parse(fs.readFileSync(cli.flags.configFile, 'utf-8'))
+      : null;
 
     const spinner = ora('working').start();
     let result;
     let processed = false;
     try {
-      result = await processPolicies(
-        projectPaths,
-        setupProjectFn,
-        spinner,
-        currentDate,
-        policyRules,
-      );
+      result = await processPolicies(projectPaths, setupProjectFn, spinner, currentDate, config);
       if (result.isInSupportWindow === false) {
         process.exitCode = 1;
       }

--- a/lib/project/multiple-projects.js
+++ b/lib/project/multiple-projects.js
@@ -7,10 +7,12 @@ const os = require('os');
 const isInSupportWindow = require('./index');
 const { isProjectExpiringSoon } = require('../output/cli-output');
 const { ProgressLogger } = require('../util');
+const { getPolicyRules } = require('./../policy-rules');
 const DEFAULT_SETUP_FILE = './setup-project';
 
 module.exports.processPolicies = processPolicies;
-async function processPolicies(projectPaths, setupProjectFn, spinner, today, policyRules) {
+async function processPolicies(projectPaths, setupProjectFn, spinner, today, config) {
+  const policyRules = getPolicyRules(config);
   const setupProject = setupProjectFn ? setupProjectFn : require(DEFAULT_SETUP_FILE);
   let result = {
     isInSupportWindow: true,
@@ -26,7 +28,8 @@ async function processPolicies(projectPaths, setupProjectFn, spinner, today, pol
   });
   let isMultipleProduct = projectPaths.length > 1;
   let progressLogger = new ProgressLogger(spinner, isMultipleProduct);
-  const ignoredDependencies = policyRules.primary.ignoredDependencies;
+  const ignoredDependencies =
+    (policyRules.primary && policyRules.primary.ignoredDependencies) || [];
   for (const projectPath of projectPaths) {
     work.push(
       queue.add(async () => {

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -1,3 +1,46 @@
 'use strict';
 
-describe('supported', function () {});
+const registries = require('./test-helpers/registries');
+
+const chai = require('chai');
+const { expect } = chai;
+const { processPolicies } = require('../index');
+
+describe('processPolicies', function () {
+  this.timeout(4000);
+  beforeEach(function () {
+    registries.startAll();
+  });
+
+  afterEach(function () {
+    registries.stopAll();
+  });
+
+  it('verifies supported project', async function () {
+    const result = await processPolicies(`${__dirname}/fixtures/supported-project`);
+    expect(result.isInSupportWindow).to.be.ok;
+  });
+
+  it('notifies of unsupported project', async function () {
+    const result = await processPolicies(`${__dirname}/fixtures/unsupported-project`);
+    expect(result.isInSupportWindow).to.not.be.ok;
+  });
+
+  it('accepts configuration to ignore dependencies', async function () {
+    const result = await processPolicies(`${__dirname}/fixtures/unsupported-project`);
+    expect(result.isInSupportWindow).to.not.be.ok;
+
+    const result2 = await processPolicies(
+      `${__dirname}/fixtures/unsupported-project`,
+      undefined,
+      undefined,
+      undefined,
+      {
+        primary: {
+          ignoredDependencies: ['es6-promise', '@stefanpenner/a', 'rsvp'],
+        },
+      },
+    );
+    expect(result2.isInSupportWindow).to.be.ok;
+  });
+});


### PR DESCRIPTION
Previously, processPolicies() took an arbitrary set of parameters derived from the configuration format. This change cleans up the public API to be just the documented configuration format in [CONFIGURATION.md](https://github.com/supportedjs/supported/blob/main/CONFIGURATION.md).