### PR TITLE
Support effectiveReleaseDate in primary policy

### DIFF
--- a/lib/project/index.js
+++ b/lib/project/index.js
@@ -87,6 +87,8 @@ module.exports = async function isInSupportWindow(
               debug(
                 `name: ${name}, effectiveReleaseDate: ${effectiveReleaseDate}, upgradeBudget: ${upgradeBudget}`,
               );
+            } else if (policies.primary.effectiveReleaseDate) {
+              effectiveReleaseDate = policies.primary.effectiveReleaseDate;
             }
             result = supported(
               info,

--- a/tests/cli-test.js
+++ b/tests/cli-test.js
@@ -404,10 +404,22 @@ describe('CLI', function () {
   });
 
   describe('--config-file', function () {
-    it('make unsupported to supported project using effectiveReleaseDate', async function () {
+    it('make unsupported to supported project using effectiveReleaseDate in custom policy', async function () {
       const child = await runSupportedCmd([
         `${__dirname}/fixtures/unsupported-project`,
         `-f ${__dirname}/fixtures/unsupported-project/config.json`,
+        `--current-date="March 31, 2021"`,
+      ]);
+
+      expect(child).to.exitGracefully();
+      expect(child.stderr).to.includes('✓ SemVer Policy');
+    });
+
+    it('make unsupported to supported project using effectiveReleaseDate in primary policy', async function () {
+      const child = await runSupportedCmd([
+        `${__dirname}/fixtures/unsupported-project`,
+        `-f ${__dirname}/fixtures/unsupported-project/config-primary-release.json`,
+        `--current-date="March 31, 2021"`,
       ]);
 
       expect(child).to.exitGracefully();

--- a/tests/fixtures/unsupported-project/config-primary-release.json
+++ b/tests/fixtures/unsupported-project/config-primary-release.json
@@ -1,0 +1,5 @@
+{
+    "primary": {
+      "effectiveReleaseDate": "1/1/2022"
+    }
+  }


### PR DESCRIPTION
Previously this feature was documented in `CONFIGURATION.md` but not supported.