### PR TITLE
Default node info object to undefined

### DIFF
--- a/lib/output/cli-output.js
+++ b/lib/output/cli-output.js
@@ -405,7 +405,7 @@ module.exports.getCategorisedList = getCategorisedList;
 function getCategorisedList(pkgList) {
   let expiresSoon = [];
   let unsupportedPackages = [];
-  let nodePackage = [];
+  let nodePackage = undefined;
   let emberCliPackage;
   let emberSourcePackage;
   let supportedPackages = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supported",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "main": "index.js",
   "repository": "git@github.com:supportedjs/supported",
   "homepage": "https://github.com/supportedjs/supported",


### PR DESCRIPTION
This ensures a clear signal if the node package info isn't resolved correctly