### PR TITLE
Handle case where lock file entries might be different in yarn 3

### DIFF
--- a/lib/project/setup-project.js
+++ b/lib/project/setup-project.js
@@ -104,6 +104,7 @@ module.exports = async function setupProject(projectRoot) {
   const lockfilePath = path.join(projectRoot, 'yarn.lock');
   // TODO: npm support
   const lockfile = new YarnLock(lockfilePath);
+
   const dependenciesToCheck = [];
   if (pkg.dependencies) {
     for (const [name, version] of Object.entries(pkg.dependencies)) {

--- a/lib/project/setup-project.js
+++ b/lib/project/setup-project.js
@@ -108,7 +108,6 @@ module.exports = async function setupProject(projectRoot) {
   if (pkg.dependencies) {
     for (const [name, version] of Object.entries(pkg.dependencies)) {
       const resolvedVersion = lockfile.resolvedVersion(name, version);
-
       if (semverCoerce(version)) {
         dependenciesToCheck.push({
           name,

--- a/lib/project/setup-project.js
+++ b/lib/project/setup-project.js
@@ -41,6 +41,19 @@ class YarnLock {
         } else if (possibleEntries.length === 1) {
           return this.lockFileContents[possibleEntries[0]].version;
         } else {
+          // Its possible for this case to look like:
+          // 'graphql@^15.5.1',
+          // 'graphql@npm:^14.7.0 || ^15.0.0 || ^16.0.0'
+          for (let i = 0; i < possibleEntries.length; i++) {
+            if (
+              possibleEntries[i].includes(`${name}@${packageJsonVersion}`) ||
+              (possibleEntries[i].includes(`${name}@`) &&
+                possibleEntries[i].includes(`${packageJsonVersion}`))
+            ) {
+              return this.lockFileContents[possibleEntries[i]].version;
+            }
+          }
+
           throw new Error(
             `Found unexpected multiple resolutions of: '${targetResolution}' in '${this.lockfilePath}'`,
           );
@@ -91,11 +104,11 @@ module.exports = async function setupProject(projectRoot) {
   const lockfilePath = path.join(projectRoot, 'yarn.lock');
   // TODO: npm support
   const lockfile = new YarnLock(lockfilePath);
-
   const dependenciesToCheck = [];
   if (pkg.dependencies) {
     for (const [name, version] of Object.entries(pkg.dependencies)) {
       const resolvedVersion = lockfile.resolvedVersion(name, version);
+
       if (semverCoerce(version)) {
         dependenciesToCheck.push({
           name,


### PR DESCRIPTION
In the yarn 3 case the code is looking for exactly: `${name}@:npm${version}` but we have some cases where that is not the format (ie we see `${name}@${version}`).

This is more of a "temp" solution. A more agnostic approach would be to do:

```js
const arb = new Arborist({ path: projectRoot });
const tree = await arb.loadActual();
tree.children.get(name).version;
```

Where we do not care about any lock file format and instead read the info from node_modules tree directly. However, the test suite in this repo is not really setup for this change.